### PR TITLE
feat: Add grayscale method to Colorus class

### DIFF
--- a/@types/main.d.ts
+++ b/@types/main.d.ts
@@ -205,5 +205,18 @@ declare module 'colorus' {
      * @return A new Colorus instance representing the color with inverted color values.
      */
     invert(): Colorus
+
+    /**
+     * Converts the current color to grayscale.
+     * @param useNTSCFormula - Whether to use the NTSC formula for conversion. (Default: `false`)
+     * @return A new Colorus object representing the grayscale color.
+     * @example
+     * // Create a Colorus object representing an RGB color
+     * const color = new Colorus('rgb(50 168 82)');
+     * color.grayscale().toRgb(); // Returns: 'rgb(137, 137, 137)'
+     * // Convert using the NTSC formula
+     * color.grayscale(true).toRgb(); // Returns 'rgb(123, 123, 123)'
+     */
+    grayscale(useNTSCFormula?: boolean): Colorus
   }
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ constructor(input?: AnyColor)
 - `alpha(amount): Colorus`: Changes the alpha (opacity) of the current color.
 - `contrastRatio(backgroundColor): number`: Gets the contrast ratio between a foreground color and its adjacent background.
 - `invert(): Colorus`: Inverts the color using sRGB values.
+- `grayscale(): Colorus`: Converts the current color to grayscale.
 
 #### Static Methods
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colorus",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Sleek and powerful color manipulation library for JavaScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/compose.js
+++ b/src/compose.js
@@ -75,3 +75,15 @@ export const alpha = ({ r, g, b, a = 1 }, amount) => {
  * @return {object} New RGB color object.
  */
 export const invert = ({ r, g, b, a = 1 }) => ({ r: 255 - r, g: 255 - g, b: 255 - b, a })
+
+/**
+ * Converts an RGB color to grayscale.
+ * @param {Object} color - An object representing an RGBA color.
+ * @param {boolean} [useNTSCFormula=false] - Whether to use the NTSC formula for conversion. (Default: `false`)
+ * @return {Object} An object representing the grayscale color.
+ */
+export const rgbToGray = ({ r, g, b, a = 1 }, useNTSCFormula = false) => {
+  const y = useNTSCFormula ? 0.299 * r + 0.587 * g + 0.114 * b : 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+  return { r: y, g: y, b: y, a }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -190,4 +190,13 @@ export class Colorus {
   invert() {
     return new Colorus(compose.invert(this.#data.rgb))
   }
+
+  /**
+   * Converts the current color to grayscale.
+   * @param {boolean} [useNTSCFormula=false] - Whether to use the NTSC formula for conversion. (Default: `false`)
+   * @return {Colorus} A new Colorus object representing the grayscale color.
+   */
+  grayscale(useNTSCFormula = false) {
+    return new Colorus(compose.rgbToGray(this.rgb, useNTSCFormula))
+  }
 }

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -1,4 +1,4 @@
-import { modBy, mix, lighten, saturate, hue, alpha, luminance } from '../src/compose'
+import { modBy, mix, lighten, saturate, hue, alpha, rgbToGray } from '../src/compose'
 
 describe('modBy', () => {
   test('should correctly modify a value', () => {
@@ -100,5 +100,42 @@ describe('alpha', () => {
     expect(result.r).toBe(color.r)
     expect(result.g).toBe(color.g)
     expect(result.b).toBe(color.b)
+  })
+})
+
+describe('rgbToGray', () => {
+  // Test for converting RGB to grayscale without using the NTSC formula
+  it('should convert RGB to grayscale without NTSC formula', () => {
+    const color = { r: 50, g: 168, b: 82, a: 1 }
+    const result = rgbToGray(color)
+    expect(result).toEqual({ r: 136.704, g: 136.704, b: 136.704, a: 1 })
+  })
+
+  // Test for converting RGB to grayscale using the NTSC formula
+  it('should convert RGB to grayscale with NTSC formula', () => {
+    const color = { r: 50, g: 168, b: 82, a: 1 }
+    const result = rgbToGray(color, true)
+    expect(result).toEqual({ r: 122.914, g: 122.914, b: 122.914, a: 1 })
+  })
+
+  // Test for converting black (0, 0, 0) to grayscale without NTSC formula
+  it('should convert black color to grayscale without NTSC formula', () => {
+    const color = { r: 0, g: 0, b: 0, a: 1 }
+    const result = rgbToGray(color)
+    expect(result).toEqual({ r: 0, g: 0, b: 0, a: 1 })
+  })
+
+  // Test for converting white (255, 255, 255) to grayscale using the NTSC formula
+  it('should convert white color to grayscale with NTSC formula', () => {
+    const color = { r: 255, g: 255, b: 255, a: 1 }
+    const result = rgbToGray(color, true)
+    expect(result).toEqual({ r: 255, g: 255, b: 255, a: 1 })
+  })
+
+  // Test for converting a color with alpha channel
+  it('should preserve alpha channel when converting to grayscale', () => {
+    const color = { r: 120, g: 60, b: 200, a: 0.5 }
+    const result = rgbToGray(color)
+    expect(result).toEqual({ r: 82.864, g: 82.864, b: 82.864, a: 0.5 })
   })
 })


### PR DESCRIPTION
This commit adds a new method `grayscale` to the Colorus class. The `grayscale` method converts the current color to grayscale, with an option to use the NTSC formula for conversion. Additionally, Jest tests have been added to ensure the correctness of the grayscale conversion functionality.

The tests cover various scenarios, including conversion without the NTSC formula, conversion with the NTSC formula, preservation of alpha channel, and handling of black and white colors.

**Details:**
- Added `grayscale` method to the Colorus class
- Implemented grayscale conversion using the rgbToGray function from compose module
- Added Jest tests for the grayscale method