### PR TITLE
fix: Colorus.invert() cannot invert colors correctly

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,7 @@ export class Colorus {
    * @return {Colorus} A new Colorus instance representing the color with inverted color values.
    */
   invert() {
-    return new Colorus(compose.invert(this.#data.rgb))
+    return new Colorus(compose.invert(this.rgb))
   }
 
   /**
@@ -206,5 +206,3 @@ export class Colorus {
     return new Colorus(compose.rgbToGray(this.rgb, useNTSCFormula))
   }
 }
-
-// console.log(new Colorus('aliceblue').rgb)

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -1,4 +1,4 @@
-import { modBy, mix, lighten, saturate, hue, alpha, rgbToGray } from '../src/compose'
+import { modBy, mix, lighten, saturate, hue, alpha, rgbToGray, invert } from '../src/compose'
 
 describe('modBy', () => {
   test('should correctly modify a value', () => {
@@ -65,6 +65,24 @@ describe('saturate', () => {
     const result = saturate(color, amount)
     expect(result.h).toBe(color.h)
     expect(result.l).toBe(color.l)
+  })
+})
+
+describe('invert', () => {
+  test('should invert black to white correctly', () => {
+    const color = { r: 255, g: 255, b: 255 }
+    const result = invert(color)
+    expect(result.r).toBe(0)
+    expect(result.g).toBe(0)
+    expect(result.b).toBe(0)
+  })
+
+  test('should invert white to black correctly', () => {
+    const color = { r: 0, g: 0, b: 0 }
+    const result = invert(color)
+    expect(result.r).toBe(255)
+    expect(result.g).toBe(255)
+    expect(result.b).toBe(255)
   })
 })
 

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -86,3 +86,9 @@ describe('Colorus.test()', () => {
     expect(Colorus.test(undefined)).toBeNull()
   })
 })
+
+describe('Colorus.invert()', () => {
+  test('should invert colors correctly', () => {
+    expect(new Colorus('crimson').invert().toRgb()).toBe('rgb(35, 235, 195)')
+  })
+})


### PR DESCRIPTION
- Now Colorus.invert() uses this.rgb for a RGB representation instead of  this.#data.rgb
- Add unit tests for invert() function in compose.spec.js module
- Add unit tests for Colorus.invert() method in main.spec.js module